### PR TITLE
Fix against "first stanza lacks a 'Source' field" message

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,10 +1,14 @@
-Package: hid-mapper
+Source: hid-mapper
 Version: 2.0.1
+Section: misc
+Priority: optional
+Maintainer: Sylvain Leroux <sylvain@chicoree.fr>
+
+Package: hid-mapper
 Section: misc
 Priority: optional
 Architecture: amd64
 Depends: libc6 (>= 2.11.3)
-Maintainer: Sylvain Leroux <sylvain@chicoree.fr>
 Description: HID event mapper
  Developed to map USB HID IR remote to keyboard events.
  Should work with any USB HID device.


### PR DESCRIPTION
With the recent build system of LibreELEC the log is flooded with following messages during compilation of hid_mapper package:

```
Executing (target): make 
dpkg-buildflags: error: syntax error in debian/control at line 10: first stanza lacks a 'Source' field
dpkg-buildflags: error: syntax error in debian/control at line 10: first stanza lacks a 'Source' field
dpkg-buildflags: error: syntax error in debian/control at line 10: first stanza lacks a 'Source' field
dpkg-buildflags: error: syntax error in debian/control at line 10: first stanza lacks a 'Source' field
dpkg-buildflags: error: syntax error in debian/control at line 10: first stanza lacks a 'Source' field
dpkg-buildflags: error: syntax error in debian/control at line 10: first stanza lacks a 'Source' field
dpkg-buildflags: error: syntax error in debian/control at line 10: first stanza lacks a 'Source' field
dpkg-buildflags: error: syntax error in debian/control at line 10: first stanza lacks a 'Source' field
```

According to this:  https://www.debian.org/doc/debian-policy/ch-controlfields.html#debian-source-package-template-control-files-debian-control some information must be splitted into 2 stanzas.